### PR TITLE
Dependabot で @types/node のメジャーバージョン更新を無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Summary
- Dependabot の設定に `@types/node` のメジャーバージョン更新を無視する設定を追加

## Test plan
- [ ] Dependabot が @types/node のメジャーバージョン更新 PR を作成しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)